### PR TITLE
Adding support for vertex separators

### DIFF
--- a/src/Metis.jl
+++ b/src/Metis.jl
@@ -55,7 +55,7 @@ module Metis
 
     nodeND{Tv}(m::SparseMatrixCSC{Tv,Cint}) = nodeND!(copy(m))
 
-    nodeND{Tv,Ti}(m::SparseMatrixCSC{Tv,Ti}) = nodeND!(convert(SparseMatrixCSC{Tv,Cint},m))
+    nodeND{Tv,Ti}(m::SparseMatrixCSC{Tv,Ti}) = nodeND(convert(SparseMatrixCSC{Tv,Cint},m))
 
     function nodeND{T<:Integer}(al::GenericAdjacencyList{T,Range1{T},Vector{Vector{T}}})
         n, xadj, adjncy = mkadj(al)
@@ -99,7 +99,12 @@ module Metis
                     &n, m.colptr, m.rowval, C_NULL, metis_options, 
                     sepSize, part)
         err == METIS_OK || error("METIS_ComputeVertexSeparator returned error code $err")
-        sepSize[1], part
+
+        sizes = zeros(Cint,3)
+        for i=1:n
+          sizes[part[i]+1] += 1
+        end
+        sizes, part
     end
 
     vertexSep{Tv}(m::SparseMatrixCSC{Tv,Cint},verbose::Integer) = vertexSep!(copy(m),verbose)
@@ -108,7 +113,7 @@ module Metis
 
     vertexSep{Tv}(m::SparseMatrixCSC{Tv,Cint}) = vertexSep!(copy(m))
 
-    vertexSep{Tv,Ti}(m::SparseMatrixCSC{Tv,Ti}) = vertexSep!(convert(SparseMatrixCSC{Tv,Cint},m))
+    vertexSep{Tv,Ti}(m::SparseMatrixCSC{Tv,Ti}) = vertexSep(convert(SparseMatrixCSC{Tv,Cint},m))
 
     function vertexSep{T<:Integer}(al::GenericAdjacencyList{T,Range1{T},Vector{Vector{T}}})
         n, xadj, adjncy = mkadj(al)
@@ -130,7 +135,12 @@ module Metis
                     &int32(n), xadj, adjncy, C_NULL, metis_options, 
                     sepSize, part)
         if (err != METIS_OK) error("METIS_ComputeVertexSeparator returned error code $err") end
-        sepSize[1], part
+
+        sizes = zeros(Int32,3)
+        for i=1:n
+          sizes[part[i]+1] += 1
+        end
+        sizes, part
     end
 
     function partGraphKway{T<:Integer}(al::GenericAdjacencyList{T,Range1{T},Vector{Vector{T}}},

--- a/src/Metis.jl
+++ b/src/Metis.jl
@@ -80,7 +80,7 @@ module Metis
         Base.SparseMatrix.fkeep!(m,(i,j,x,other) -> i != j, None)
         metis_options[METIS_OPTION_DBGLVL] = verbose
         n = convert(Cint, m.n)
-        sepSize = Cint()
+        sepSize::Cint = 0
         part = Array(Cint, n)
         err = ccall((:METIS_ComputeVertexSeparator,libmetis), Cint,
                     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
@@ -101,7 +101,7 @@ module Metis
 
     function vertexSep{T<:Integer}(al::GenericAdjacencyList{T,Range1{T},Vector{Vector{T}}})
         n, xadj, adjncy = mkadj(al)
-        sepSize = Cint()
+        sepSize::Int32 = 0
         part = Array(Int32, n)
         err = ccall((:METIS_ComputeVertexSeparator,libmetis), Int32,
                     (Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32},

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,3 +33,100 @@ objval, part = partGraphRecursive(copter2,6)
 mdual = Metis.testgraph("mdual")
 objval, part = partGraphKway(mdual, 10)
 @test counts(part,10) == [25789,25731,25790,25998,25728,25724,25722,26061,25995,26031]
+
+copter2 = Metis.testgraph("copter2")
+# There does not seem to be a simple way to copy a graph...
+copter2Copy = Metis.testgraph("copter2")
+sepSize, copterPart = vertexSep(copter2Copy)
+
+function testGraphPart(g,part)
+  n = length(copter2.vertices)
+  validPart = true
+  for i=1:n
+    partVal = part[i]
+    if partVal == 0
+      for j in g.adjlist[i] 
+        if part[j] == 1
+          println("Edge ($i,$j) connects sets 0 and 1")
+          validPart = false
+        end
+      end
+    elseif partVal == 1
+      for j in g.adjlist[i] 
+        if part[j] == 0
+          println("Edge ($i,$j) connects sets 1 and 0")
+          validPart = false
+        end
+      end
+    elseif partVal != 2
+      println("Vertex $i assigned to set $partVal")
+      validPart = false
+    end
+  end
+  validPart
+end
+
+@test testGraphPart(copter2,copterPart)
+
+nx = 100
+ny = 110
+A = speye(nx*ny,nx*ny)
+ACopy = speye(nx*ny,nx*ny)
+# NOTE: At this time, copy(A) does not produce a deep copy
+for x=1:nx
+  for y=1:ny
+    s = x + (y-1)*nx
+    A[s,s] = 4
+    ACopy[s,s] = 4
+    if x > 1
+      A[s,s-1] = -1
+      ACopy[s,s-1] = -1
+    end
+    if x < nx
+      A[s,s+1] = -1
+      ACopy[s,s+1] = -1
+    end
+    if y > 1
+      A[s,s-nx] = -1
+      ACopy[s,s-nx] = -1
+    end
+    if y < ny
+      A[s,s+nx] = -1
+      ACopy[s,s+nx] = -1
+    end
+  end
+end
+
+sepSize, matPart = vertexSep(A) 
+
+function testMatPart(m,part)
+  validPart = true
+  n = m.n
+  validPart = true
+  for i=1:n
+    partVal = part[i]
+    if partVal == 0
+      for k in m.colptr[i]:m.colptr[i+1]-1 
+        j = m.rowval[k]
+        if part[j] == 1
+          println("Nonzero ($i,$j) connects sets 0 and 1")
+          validPart = false
+        end
+      end
+    elseif partVal == 1
+      for k in m.colptr[i]:m.colptr[i+1]-1 
+        j = m.rowval[k]
+        if part[j] == 0
+          println("Nonzero ($i,$j) connects sets 1 and 0")
+          validPart = false
+        end
+      end
+    elseif partVal != 2
+      println("Vertex $i assigned to set $partVal")
+      validPart = false
+    end
+  end
+  validPart
+end
+
+@test testMatPart(ACopy,matPart)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,9 +35,7 @@ objval, part = partGraphKway(mdual, 10)
 @test counts(part,10) == [25789,25731,25790,25998,25728,25724,25722,26061,25995,26031]
 
 copter2 = Metis.testgraph("copter2")
-# There does not seem to be a simple way to copy a graph...
-copter2Copy = Metis.testgraph("copter2")
-sepSize, copterPart = vertexSep(copter2Copy)
+sizes, copterPart = vertexSep(copter2)
 
 function testGraphPart(g,part)
   n = length(copter2.vertices)
@@ -71,33 +69,26 @@ end
 nx = 100
 ny = 110
 A = speye(nx*ny,nx*ny)
-ACopy = speye(nx*ny,nx*ny)
-# NOTE: At this time, copy(A) does not produce a deep copy
 for x=1:nx
   for y=1:ny
     s = x + (y-1)*nx
     A[s,s] = 4
-    ACopy[s,s] = 4
     if x > 1
       A[s,s-1] = -1
-      ACopy[s,s-1] = -1
     end
     if x < nx
       A[s,s+1] = -1
-      ACopy[s,s+1] = -1
     end
     if y > 1
       A[s,s-nx] = -1
-      ACopy[s,s-nx] = -1
     end
     if y < ny
       A[s,s+nx] = -1
-      ACopy[s,s+nx] = -1
     end
   end
 end
 
-sepSize, matPart = vertexSep(A) 
+sizes, matPart = vertexSep(A) 
 
 function testMatPart(m,part)
   validPart = true
@@ -129,4 +120,4 @@ function testMatPart(m,part)
   validPart
 end
 
-@test testMatPart(ACopy,matPart)
+@test testMatPart(A,matPart)


### PR DESCRIPTION
The following changeset should (hopefully) add support for computing a vertex separator of a graph or sparse matrix. Please note that I have not yet tested for correctness since doing so via Pkg.clone() would seem to require me to rename the repository to something other than 'Metis' to avoid conflicting with the official package (please correct me if there is an easier way!).