### PR TITLE
Syntax fixes & One bug fix (?)

### DIFF
--- a/src/Metis.jl
+++ b/src/Metis.jl
@@ -26,8 +26,8 @@ module Metis
     function nodeND(x,verbose::Integer=0)
         n,xadj,adjncy = metisform(x)
         metis_options[METIS_OPTION_DBGLVL] = verbose
-        perm = Array(Cint, n)
-        iperm = Array(Cint, n)
+        perm = Array{Cint}(n)
+        iperm = Array{Cint}(n)
         err = ccall((:METIS_NodeND,libmetis), Cint,
                     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
                      Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -41,7 +41,7 @@ module Metis
 
         metis_options[METIS_OPTION_DBGLVL] = verbose
         sepSize = zeros(Cint, 1)
-        part = Array(Cint, n)
+        part = Array{Cint}(n)
 
         err = ccall((:METIS_ComputeVertexSeparator,libmetis), Cint,
                     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
@@ -59,7 +59,7 @@ module Metis
 
     function partGraphKway(x, nparts::Integer)
         n, xadj, adjncy = metisform(x)
-        part = Array(Cint, n)
+        part = Array{Cint}(n)
         objval = zeros(Cint, 1)
         err = ccall((:METIS_PartGraphKway,libmetis), Int32,
                     (Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32},
@@ -73,15 +73,15 @@ module Metis
 
     function partGraphRecursive(x, nparts::Integer)
         n, xadj, adjncy = metisform(x)
-        part = Array(Int32, n)
+        part = Array{Int32}(n)
         objval = zeros(Int32, 1)
-        err = ccall((:METIS_PartGraphKway,libmetis), Int32,
+        err = ccall((:METIS_PartGraphRecursive,libmetis), Int32,
                     (Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32},
                      Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32},
                      Ptr{Int32}, Ptr{Int32}, Ptr{Int32}),
                     &n, &one(Int32), xadj, adjncy, C_NULL, C_NULL, C_NULL, &convert(Int32,nparts),
                     C_NULL, C_NULL, metis_options, objval, part)
-        err == METIS_OK || error("METIS_PartGraphKWay returned error code $err")
+        err == METIS_OK || error("METIS_PartGraphRecursive returned error code $err")
         objval[1], part .+ one(Cint)
     end
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -12,14 +12,14 @@ end
 function metisform(al::Graphs.GenericAdjacencyList)
     !Graphs.is_directed(al) || error("Metis functions require undirected graphs")
     @compat isa(al.vertices,UnitRange) && first(al.vertices) == 1 || error("Vertices must be numbered from 1")
-    @compat length(al.adjlist), round(Int32, cumsum(vcat(0, map(length, al.adjlist)))),
-        round(Int32, flatten(al.adjlist)) .- one(Int32)
+    @compat length(al.adjlist), round.(Int32, cumsum(vcat(0, map(length, al.adjlist)))),
+        round.(Int32, flatten(al.adjlist)) .- one(Int32)
 end
 
 ## Create the 0-based column pointers and row indices of a symmetric sparse matrix
 ## after eliminating self-edges.  This is the form required by Metis functions.
 function metisform(m::SparseMatrixCSC)
-    issym(m) || ishermitian(m) || error("m must be symmetric or Hermitian")
+    issymmetric(m) || ishermitian(m) || error("m must be symmetric or Hermitian")
 
     ## copy m.rowval and m.colptr to Int32 vectors dropping diagonal elements
     adjncy = @compat sizehint!(Cint[],nnz(m))
@@ -43,18 +43,18 @@ function metisform(g::LightGraphs.Graph)
     xadj = zeros(Int32,n + 1)
     adjncy = sizehint!(Int32[],2*ne(g))
     for i in 1:n
-        ein = [convert(Int32,dst(x)-1) for x in LightGraphs.out_edges(g, i)]
+        ein = [convert(Int32,x-1) for x in LightGraphs.neighbors(g, i)]
         xadj[i + 1] = xadj[i] + length(ein)
         append!(adjncy,ein)
     end
     n, xadj, adjncy
 end
 
-function testgraph(nm::ASCIIString)
+function testgraph(nm::String)
     pathnm = joinpath(dirname(@__FILE__), "..", "graphs", string(nm, ".graph"))
     ff = open(pathnm, "r")
     nvert, nedge = map(t -> parse(Int, t), split(readline(ff)))
-    adjlist = Array(Vector{Int32}, nvert)
+    adjlist = Array{Vector{Int32}}(nvert)
     for i in 1:nvert adjlist[i] = map(t -> parse(Int32, t), split(readline(ff))) end
     close(ff)
     @compat GenericAdjacencyList{Int32,UnitRange{Int32},Vector{Vector{Int32}}}(false,


### PR DESCRIPTION
Proposing a few syntax fixes, and one fix to partGraphRecursive that was calling partGraphKway ?
--------
Syntax fixes
(1) Fixing syntax change Array(T, n) -> Array{T, n)
(2) Fixing syntax change for elementwise operations (round -> round.)
(3) Fixing syntax change issym -> issymmetric
(4) Using String instead of ASCIIString

Fix for lightgraph
(5) Using neighbors instead of out_edges

Important change
(6) For some reason, partGraphRecursive was using partGraphKway ... ? Now using partGraphRecursive, as it probably should
