### PR TITLE
Adding support for edge weights (using SimpleWeightedGraphs)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.0.0"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 METIS_jll = "d00139f3-1899-568f-a2f0-47f597d42d70"
+SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/src/Metis.jl
+++ b/src/Metis.jl
@@ -96,7 +96,7 @@ function graph(G::SimpleWeightedGraphs.AbstractSimpleWeightedGraph)
     xadj = Vector{idx_t}(undef, N+1)
     xadj[1] = 1
     adjncy = Vector{idx_t}(undef, 2*SimpleWeightedGraphs.ne(G))
-    vwgt = zeros(idx_t, N)
+    vwgt = ones(idx_t, N)
     adjwgt = Vector{idx_t}(undef, 2*SimpleWeightedGraphs.ne(G))
     adjncy_i = 0
     for j in 1:N

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ end
     T = LightGraphs.smallgraph(:tutte)
     for G in (S, T), alg in (:RECURSIVE, :KWAY), nparts in (3, 4)
         partition = Metis.partition(G, nparts, alg = alg)
-        @test extrema(partition) == (1, nparts)
+        @test extrema(partition) == (2, nparts)
         @test all(x -> findfirst(==(x), partition) !== nothing, 1:nparts)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Random
 using Test
 using SparseArrays
 import LightGraphs
+import SimpleWeightedGraphs
 
 @testset "Metis.permutation" begin
     Random.seed!(0)
@@ -18,6 +19,21 @@ end
     S = sprand(10, 10, 0.5); S = S + S'; fill(S.nzval, 1)
     T = LightGraphs.smallgraph(:tutte)
     for G in (S, T), alg in (:RECURSIVE, :KWAY), nparts in (3, 4)
+        partition = Metis.partition(G, nparts, alg = alg)
+        @test extrema(partition) == (1, nparts)
+        @test all(x -> findfirst(==(x), partition) !== nothing, 1:nparts)
+    end
+end
+
+@testset "Metis.partition with edge weights" begin
+    T = LightGraphs.smallgraph(:tutte)
+    G = SimpleWeightedGraphs.SimpleWeightedGraph(LightGraphs.nv(T))
+    for i in 1:LightGraphs.nv(T)
+        for j in LightGraphs.neighbors(T, i)
+            SimpleWeightedGraphs.add_edge!(G, i, j, 1)
+        end
+    end
+    for alg in (:RECURSIVE, :KWAY), nparts in (3, 4)
         partition = Metis.partition(G, nparts, alg = alg)
         @test extrema(partition) == (1, nparts)
         @test all(x -> findfirst(==(x), partition) !== nothing, 1:nparts)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ end
     T = LightGraphs.smallgraph(:tutte)
     for G in (S, T), alg in (:RECURSIVE, :KWAY), nparts in (3, 4)
         partition = Metis.partition(G, nparts, alg = alg)
-        @test extrema(partition) == (2, nparts)
+        @test extrema(partition) == (1, nparts)
         @test all(x -> findfirst(==(x), partition) !== nothing, 1:nparts)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,9 +34,9 @@ end
         end
     end
     for alg in (:RECURSIVE, :KWAY), nparts in (3, 4)
+        unwpartition = Metis.partition(T, nparts, alg = alg)
         partition = Metis.partition(G, nparts, alg = alg)
-        @test extrema(partition) == (1, nparts)
-        @test all(x -> findfirst(==(x), partition) !== nothing, 1:nparts)
+        @test partition == unwpartition
     end
 end
 


### PR DESCRIPTION
Hello! First of all, please note that I'm quite new to Julia and this is my first time contributing to a project.

Inspired by #35, I decided to modify the `partition` function in order to be able to use weights on edges. At first I thought of just adding an extra argument with the `adjwgt` vector with the weights, but this vector would have to be constructed by the user in the Metis CSR format which is not very friendly.
So, I decided to add a method  for  the `graph()` function that converts a weighted graph from [SimpleWeightedGraphs.jl](https://github.com/JuliaGraphs/SimpleWeightedGraphs.jl) into a CSR graph.

A few things that I'm not sure about (and that I would be thankful to know your opinions on):

- I don't know how to add `SimpleWeightedGraphs` to the package's dependencies. Every time I do `using Metis` in the REPL I get the message: "Warning: Package Metis does not have SimpleWeightedGraphs in its dependencies".
- I couldn't find a way of having an inner constructor for `Graph` that would ignore the `vwgt` field but not `adjwgt`. What I ended up doing was setting `vwgt` to a vector of zeros (this should not affect the behavior of METIS).
- I don't know how to write tests for these changes.

Thanks in advance for the chance of contributing!  