### PR TITLE
Migrate from LightGraphs to Graphs.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,13 +3,13 @@ uuid = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 version = "1.0.0"
 
 [deps]
-LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 METIS_jll = "d00139f3-1899-568f-a2f0-47f597d42d70"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-LightGraphs = "1"
+Graphs = "1.4.1"
 METIS_jll = "5.1"
 julia = "1.3"
 

--- a/src/Metis.jl
+++ b/src/Metis.jl
@@ -2,7 +2,7 @@ module Metis
 
 using SparseArrays
 using LinearAlgebra
-import LightGraphs
+import Graphs
 using METIS_jll: libmetis
 
 # Metis C API
@@ -59,19 +59,19 @@ function graph(G::SparseMatrixCSC; check_hermitian=true)
 end
 
 """
-    graph(G::LightGraphs.AbstractSimpleGraph)
+    graph(G::Graphs.AbstractSimpleGraph)
 
-Construct the 1-based CSR representation of the `LightGraphs` graph `G`.
+Construct the 1-based CSR representation of the `Graphs.jl` graph `G`.
 """
-function graph(G::LightGraphs.AbstractSimpleGraph)
-    N = LightGraphs.nv(G)
+function graph(G::Graphs.AbstractSimpleGraph)
+    N = Graphs.nv(G)
     xadj = Vector{idx_t}(undef, N+1)
     xadj[1] = 1
-    adjncy = Vector{idx_t}(undef, 2*LightGraphs.ne(G))
+    adjncy = Vector{idx_t}(undef, 2*Graphs.ne(G))
     adjncy_i = 0
     for j in 1:N
         ne = 0
-        for i in LightGraphs.outneighbors(G, j)
+        for i in Graphs.outneighbors(G, j)
             ne += 1
             adjncy_i += 1
             adjncy[adjncy_i] = i

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Metis
 using Random
 using Test
 using SparseArrays
-import LightGraphs
+import Graphs
 
 @testset "Metis.permutation" begin
     Random.seed!(0)
@@ -16,7 +16,7 @@ end
 @testset "Metis.partition" begin
     Random.seed!(0)
     S = sprand(10, 10, 0.5); S = S + S'; fill(S.nzval, 1)
-    T = LightGraphs.smallgraph(:tutte)
+    T = Graphs.smallgraph(:tutte)
     for G in (S, T), alg in (:RECURSIVE, :KWAY), nparts in (3, 4)
         partition = Metis.partition(G, nparts, alg = alg)
         @test extrema(partition) == (1, nparts)
@@ -27,7 +27,7 @@ end
 @testset "Metis.separator" begin
     Random.seed!(0)
     S = sprand(10, 10, 0.5); S = S + S'; fill(S.nzval, 1)
-    T = LightGraphs.smallgraph(:tutte)
+    T = Graphs.smallgraph(:tutte)
     for G in (S, T)
         parts = Metis.separator(G)
         @test extrema(parts) == (1, 3)


### PR DESCRIPTION
As you my know, development of LightGraphs has been moved to [Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl). The announcement can be found [here](https://discourse.julialang.org/t/lightgraphs-jl-transition/69526/17?u=simonschoelly).

This PR migrates this package to Graphs.jl. Technically such a change is breaking, as this package exports functions that take a `LightGraphs` graphs as an argument, so that could cause some issue with downstream packages, but it's probably overkill to bumb the version to 2.0.