### PR TITLE
Add support for edge weights from sparse matrix input.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Metis"
 uuid = "2679e427-3c69-5b7f-982b-ece356f1e94b"
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,25 @@ using Test
 using SparseArrays
 import LightGraphs, Graphs
 
+@testset "Metis.graph(::SparseMatrixCSC)" begin
+    rng = MersenneTwister(0)
+    S = sprand(rng, Int, 10, 10, 0.2); S = S + S'; fill!(S.nzval, 1)
+    foreach(i -> S[i, i] = 0, 1:10); dropzeros!(S)
+    g = Metis.graph(S)
+    gw = Metis.graph(S; weights=true)
+    @test g.xadj == gw.xadj
+    @test g.adjncy == gw.adjncy
+    @test g.adjwgt == C_NULL
+    @test gw.adjwgt == ones(Int, length(gw.adjncy))
+    G  = SparseMatrixCSC(10, 10, g.xadj, g.adjncy, ones(Int, length(g.adjncy)))
+    GW = SparseMatrixCSC(10, 10, gw.xadj, gw.adjncy, gw.adjwgt)
+    @test iszero(S - G)
+    @test iszero(S - GW)
+end
+
 @testset "Metis.permutation" begin
     rng = MersenneTwister(0)
-    S = sprand(rng, 10, 10, 0.5); S = S + S'; fill(S.nzval, 1)
+    S = sprand(rng, 10, 10, 0.5); S = S + S'; fill!(S.nzval, 1)
     perm, iperm = Metis.permutation(S)
     @test isperm(perm)
     @test isperm(iperm)
@@ -15,10 +31,11 @@ end
 
 @testset "Metis.partition" begin
     rng = MersenneTwister(0)
-    S = sprand(rng, 10, 10, 0.5); S = S + S'; fill(S.nzval, 1)
+    S = sprand(rng, Int, 10, 10, 0.5); S = S + S'; fill!(S.nzval, 1)
+    SG = Metis.graph(S; weights=true)
     T = Graphs.smallgraph(:tutte)
     TL = LightGraphs.smallgraph(:tutte)
-    for G in (S, T, TL), alg in (:RECURSIVE, :KWAY), nparts in (3, 4)
+    for G in (S, T, TL, SG), alg in (:RECURSIVE, :KWAY), nparts in (3, 4)
         partition = Metis.partition(G, nparts, alg = alg)
         @test extrema(partition) == (1, nparts)
         @test all(x -> findfirst(==(x), partition) !== nothing, 1:nparts)
@@ -27,7 +44,8 @@ end
 
 @testset "Metis.separator" begin
     rng = MersenneTwister(0)
-    S = sprand(rng, 10, 10, 0.5); S = S + S'; fill(S.nzval, 1)
+    S = sprand(rng, 10, 10, 0.5); S = S + S'; fill!(S.nzval, 1)
+    SG = Metis.graph(S; weights=true)
     T = Graphs.smallgraph(:tutte)
     TL = LightGraphs.smallgraph(:tutte)
     for G in (S, T, TL)


### PR DESCRIPTION
This patch adds the weights keyword argument to Metis.graph to construct
a Metis.Graph with edge weights based on the matrix entries, i.e.:

    g = Metis.graph(A; weights=true)

Note that the weights must be integers.